### PR TITLE
Fixed characters header link, moving MAL score up, and fixed double number on OPs/EDs

### DIFF
--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -748,6 +748,53 @@
 
 		},
 
+		seasonal:{
+			running: false,
+
+			stopRunning() {
+				this.running = false;
+			},
+
+			init() {
+				if (this.running) return;
+
+				this.running = true;
+
+				this.addSeasonLink();
+
+				return this.stopRunning();
+			},
+
+			addSeasonLink() {
+				if (!$('.browse-wrap .dropdown .primary-links .secondary-links')) return;
+				if ($('.seasonal-anime')) return;
+ 
+				const linksEl = $('.secondary-links')
+				const attrName = linksEl.childNodes[0].attributes[0].name;
+
+				// Determine the year and season
+				const year = new Date().getFullYear();
+				const month = new Date().getMonth();
+				var season = "";
+				if (month <= 2){
+					season = "WINTER";
+				}else if(month <= 5){
+					season = "SPRING";
+				}else if(month <= 8){
+					season = "SUMMER";
+				}else{
+					season = "FALL";
+				}
+				var ref = "/search/anime?year=" + year + "&season=" + season;
+
+				// Create the new element and add to the dropdown
+				const link = anilist.helpers.createElement('a', { class: 'seasonal-anime', [attrName]: '', href: ref});
+				link.innerHTML = "Seasonal"
+
+				linksEl.append(link);
+			}
+		},
+
 		staff: {
 
 			running: false,
@@ -1036,7 +1083,6 @@
 			if (anilist.helpers.page(/^\/(anime|manga)\/\d+\/[\w\d-_]+(\/)?$/)) {
 
 				anilist.overview.init();
-
 			}
 
 			if (anilist.helpers.page(/^\/(anime|manga)\/.+\/characters$/)) {
@@ -1056,7 +1102,7 @@
 				anilist.social.init();
 
 			}
-
+			anilist.seasonal.init();
 		}
 
 	});

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -157,18 +157,20 @@
 			addMalLink(malID, isAnime) {
 				if ($('.MyAnimeList') || !$('.sidebar')) return;
 
-				let extLinksEl = $('.external-links');
-				const attrEl = $('.external-links > a');
+				let extLinksWrapEl = $('.external-links .external-links-wrap');
+				const attrEl = $('.external-links .external-links-wrap > a');
 				let attrName;
+
+				console.log(attrEl);
 
 				if (attrEl) {
 					attrName = attrEl.attributes[0].name;
 				} else {
 					// Setting the "data-v-" attribute manually is not ideal as
 					// this could change in the future but it'll do for now.
-					attrName = 'data-v-1a2276d0';
+					attrName = 'data-v-7a1f9df8';
 
-					extLinksEl = anilist.helpers.createElement('div', {
+					const extLinksEl = anilist.helpers.createElement('div', {
 						[attrName]: '',
 						class: 'external-links external-links-extras'
 					});
@@ -176,6 +178,9 @@
 					const extLinksTitle = anilist.helpers.createElement('h2');
 					extLinksTitle.innerText = "External & Streaming links";
 					extLinksEl.append(extLinksTitle);
+
+					extLinksWrapEl = anilist.helpers.createElement('div', { class: 'external-links-wrap' });
+					extLinksEl.append(extLinksWrapEl);
 
 					$('.sidebar').append(extLinksEl);
 				}
@@ -188,7 +193,7 @@
 				});
 				malLink.innerText = 'MyAnimeList';
 
-				extLinksEl.append(malLink);
+				extLinksWrapEl.append(malLink);
 			},
 
 			addMalScore() {

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -410,7 +410,12 @@
 							[attrName]: '',
 							class: `tag ${index > 5 ? 'showmore hide' : ''}`
 						}, { marginBottom: '10px' });
-						opCard.innerText = `#${parseInt(index, 10) + 1}: ${song}`;
+						// Only add num if not already
+						const title = song;
+						if (!title.startsWith("#")){
+							title = "#" + parseInt(index, 10) + 1 + title;
+						}
+						opCard.innerText = `${title}`;
 						opContainer.append(opCard);
 					}
 
@@ -465,7 +470,12 @@
 							[attrName]: '',
 							class: `tag ${index > 5 ? 'showmore hide' : ''}`
 						}, { marginBottom: '10px' });
-						edCard.innerText = `#${parseInt(index, 10) + 1}: ${song}`;
+						// Only add num if not already
+						const title = song;
+						if (!title.startsWith("#")){
+							title = "#" + parseInt(index, 10) + 1 + title;
+						}
+						edCard.innerText = `${title}`;
 						edContainer.append(edCard);
 					}
 

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -199,7 +199,6 @@
 					class: 'type'
 				});
 
-
 				malScoreHeader.innerText = 'MyAnimeList Score';
 
 				const malScoreValue = anilist.helpers.createElement('div', {
@@ -213,26 +212,12 @@
 
 				malScoreContainer.append(malScoreHeader, malScoreValue);
 
-				var added = false;
-				const dataNodes = $('.data').children;
+				const dataNodes = Array.from($$('.data-set'));
+				const targetNode = dataNodes.find(el => /popularity/i.test(el.innerText));
 
-				for(var i = 0; i < dataNodes.length; i++){
-					if (dataNodes[i].innerHTML != null && dataNodes[i].innerHTML.includes('Popularity')){
-						// Place the MAL score before the anilist popularity, this will ensure it is just after the AL score
-						// In the case where there is no AL score, this will still ensure it is in the expected location
-
-						// So we can do the .before, the popularity element needs a unique class name
-						var node = dataNodes[i];
-						var origClass = node.className;
-						node.className = "popularity";
-						$('.popularity').before(malScoreContainer);
-						node.className = origClass; 
-						added = true;
-						break;
-					}
-				}
-				if (added == false){
-					// this will append just in case it didn't get caught before
+				if (targetNode) {
+					targetNode.before(malScoreContainer);
+				} else {
 					$('.data').append(malScoreContainer);
 				}
 			},

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -177,7 +177,18 @@
 
 				malScoreContainer.append(malScoreHeader, malScoreValue);
 
-				$('.data').append(malScoreContainer);
+				const dataNodes = $('.data').childNodes;
+				
+				for(var i = 0; i < dataNodes.length; i++){
+					if(dataNodes[i].innerHTML != null && dataNodes[i].innerHTML.includes('Mean Score')){
+						var node = dataNodes[i];
+						var origClass = node.className;
+						node.className = "meanscore";
+						$('.meanscore').after(malScoreContainer);
+						node.className = origClass; 
+						break;
+					}
+				}
 
 			},
 

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -183,17 +183,33 @@
 
 				malScoreContainer.append(malScoreHeader, malScoreValue);
 
+				var added = false;
 				const dataNodes = $('.data').childNodes;
 
 				for(var i = 0; i < dataNodes.length; i++){
 					if(dataNodes[i].innerHTML != null && dataNodes[i].innerHTML.includes('Mean Score')){
+						// probably not necessary with the if below, but I want it to be after the mean score for sure
 						var node = dataNodes[i];
 						var origClass = node.className;
 						node.className = "meanscore";
 						$('.meanscore').after(malScoreContainer);
 						node.className = origClass; 
+						added = true;
+						break;
+					}else if (dataNodes[i].innerHTML != null && dataNodes[i].innerHTML.includes('Popularity')){
+						// this will append in the correct place if there is no anilist score
+						var node = dataNodes[i];
+						var origClass = node.className;
+						node.className = "popularity";
+						$('.popularity').before(malScoreContainer);
+						node.className = origClass; 
+						added = true;
 						break;
 					}
+				}
+				if (added == false){
+					// this will append just in case it didn't get caught before
+					$('.data').append(malScoreContainer);
 				}
 
 			},

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -128,47 +128,31 @@
 			},
 
 			addMalLink(malID, isAnime) {
-				// If for some reason there are two external links containers, remove the second one
-				// This is usually caused by this script running before Anilist's javascript can add the external links
-				if ($('.MyAnimeList') && $$('.external-links').length == 2){
-					if ($('.external-links-extras > a') != null){
-						$('.external-links').append($('.external-links-extras > a'));
-					}
-					$('.external-links-extras').parentNode.removeChild($('.external-links-extras'));
-				}
+				if ($('.MyAnimeList') || !$('.sidebar')) return;
 
-				if ($('.MyAnimeList')) return; // If already added, return
-
-				var extLinksEl = $('.external-links');
+				let extLinksEl = $('.external-links');
 				const attrEl = $('.external-links > a');
-				var attrName = 'data-v-1a2276d0';
+				let attrName;
 
-				if (attrEl){
-					// Like normal, add MAL link below streaming links, get the attribute name of the other links
+				if (attrEl) {
 					attrName = attrEl.attributes[0].name;
+				} else {
+					// Setting the "data-v-" attribute manually is not ideal as
+					// this could change in the future but it'll do for now.
+					attrName = 'data-v-1a2276d0';
 
-				}else{	
-					// No external links, lets create the header
-					if (!$('.sidebar')) return;
-					const sidebarEl = $('.sidebar');
+					extLinksEl = anilist.helpers.createElement('div', {
+						[attrName]: '',
+						class: 'external-links external-links-extras'
+					});
 
-					if (extLinksEl == null){
-						// There are no external or streaming links then recreate the div		
-						extLinksEl = anilist.helpers.createElement('div', {
-							['data-v-1a2276d0']: '',
-							class: 'external-links external-links-extras'
-						});
-						sidebarEl.append(extLinksEl);
+					const extLinksTitle = anilist.helpers.createElement('h2');
+					extLinksTitle.innerText = "External & Streaming links";
+					extLinksEl.append(extLinksTitle);
 
-						// Create the title
-						const extLinksTitle = anilist.helpers.createElement('h2', {
-						});
-						extLinksTitle.innerText = "External & Streaming Links";
-						extLinksEl.append(extLinksTitle);
-					}
+					$('.sidebar').append(extLinksEl);
 				}
 
-				// Create the link
 				const malLink = anilist.helpers.createElement('a', {
 					[attrName]: '',
 					class: 'external-link MyAnimeList',
@@ -176,7 +160,7 @@
 					href: `https://myanimelist.net/${isAnime ? 'anime' : 'manga'}/${malID}/`
 				});
 				malLink.innerText = 'MyAnimeList';
-				
+
 				extLinksEl.append(malLink);
 			},
 
@@ -545,7 +529,7 @@
 			cleanUp() {
 				if ($('.characters')) $('.characters').classList.remove('mal');
 				if ($('.character-header')) $('.character-header').innerText = 'Characters';
-				const elements = $$('.MyAnimeList, .mal-score, .toggle, .grid-wrap.mal, #toggleCharacters, .openings, .endings');
+				const elements = $$('.MyAnimeList, .external-links-extras, .mal-score, .toggle, .grid-wrap.mal, #toggleCharacters, .openings, .endings');
 				for (const el of elements) el.remove();
 				this.currentData = null;
 			}

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -381,8 +381,13 @@
 					$('.characters .link').insertAdjacentHTML('afterend', `
 						<span class="character-header">MAL Characters</span>
 						<span class="toggle"></span>
+					`);
+
+					if ($('.characters .toggle') && $('.characters .switcher-holder') == null){
+						$('.characters .toggle').insertAdjacentHTML('afterend', `
 						<div class="switcher-holder"></div>
 					`);
+					}
 					
 					$('.characters .toggle').addEventListener('click', () => {
 						if ($('.characters').classList.contains('mal')) {

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -374,6 +374,7 @@
 
 			displayStaffViewSwitcher(){
 				if ($('.staff .switcher-holder')) return;
+				if (!$('.staff .link')) return;
 
 				try {
 					$('.staff .link').insertAdjacentHTML('afterend', `
@@ -410,12 +411,11 @@
 							[attrName]: '',
 							class: `tag ${index > 5 ? 'showmore hide' : ''}`
 						}, { marginBottom: '10px' });
-						// Only add num if not already
-						const title = song;
-						if (!title.startsWith("#")){
-							title = "#" + parseInt(index, 10) + 1 + title;
+						if (!song.startsWith("#")){
+							opCard.innerText = `#${parseInt(index, 10) + 1}: ${song}`;
+						}else{
+							opCard.innerText = `${song}`;
 						}
-						opCard.innerText = `${title}`;
 						opContainer.append(opCard);
 					}
 
@@ -471,11 +471,11 @@
 							class: `tag ${index > 5 ? 'showmore hide' : ''}`
 						}, { marginBottom: '10px' });
 						// Only add num if not already
-						const title = song;
-						if (!title.startsWith("#")){
-							title = "#" + parseInt(index, 10) + 1 + title;
+						if (!song.startsWith("#")){
+							edCard.innerText = `#${parseInt(index, 10) + 1}: ${song}`;
+						}else{
+							edCard.innerText = `${song}`;
 						}
-						edCard.innerText = `${title}`;
 						edContainer.append(edCard);
 					}
 

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -134,20 +134,47 @@
 
 				const attrEl = $('.external-links > a');
 
-				if (!attrEl) return;
+				if (attrEl){
+					// Like normal, add MAL link below streaming links
+					const attrName = attrEl.attributes[0].name;
 
-				const attrName = attrEl.attributes[0].name;
+					const malLink = anilist.helpers.createElement('a', {
+						[attrName]: '',
+						class: 'external-link MyAnimeList',
+						target: '_blank',
+						href: `https://myanimelist.net/${isAnime ? 'anime' : 'manga'}/${malID}/`
+					});
+	
+					malLink.innerText = 'MyAnimeList';
+	
+					extLinksEl.append(malLink);
+				}else{
+					if (!$('.sidebar')) return;
+					// There are no external or streaming links then recreate the div					
+					const sidebarEl = $('.sidebar');
+					const extLinksEl = anilist.helpers.createElement('div', {
+						['data-v-1a2276d0']: '',
+						class: 'external-links'
+					});
 
-				const malLink = anilist.helpers.createElement('a', {
-					[attrName]: '',
-					class: 'external-link MyAnimeList',
-					target: '_blank',
-					href: `https://myanimelist.net/${isAnime ? 'anime' : 'manga'}/${malID}/`
-				});
+					// Create the title
+					const extLinksTitle = anilist.helpers.createElement('h2', {
+					});
+					extLinksTitle.innerText = "External & Streaming Links";
+					extLinksEl.append(extLinksTitle);
 
-				malLink.innerText = 'MyAnimeList';
-
-				extLinksEl.append(malLink);
+					sidebarEl.append(extLinksEl);
+					
+					const malLink = anilist.helpers.createElement('a', {
+						['data-v-1a2276d0']: '',
+						class: 'external-link MyAnimeList',
+						target: '_blank',
+						href: `https://myanimelist.net/${isAnime ? 'anime' : 'manga'}/${malID}/`
+					});
+					malLink.innerText = 'MyAnimeList';
+	
+					extLinksEl.append(malLink);
+				}
 			},
 
 			addMalScore() {

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -128,27 +128,27 @@
 			},
 
 			addMalLink(malID, isAnime) {
-				if ($('.MyAnimeList')) return;
+				// If for some reason there are two external links containers, remove the second one
+				// This is usually caused by this script running before Anilist's javascript can add the external links
+				if ($('.MyAnimeList') && $$('.external-links').length == 2){
+					if ($('.external-links-extras > a') != null){
+						$('.external-links').append($('.external-links-extras > a'));
+					}
+					$('.external-links-extras').parentNode.removeChild($('.external-links-extras'));
+				}
+
+				if ($('.MyAnimeList')) return; // If already added, return
 
 				var extLinksEl = $('.external-links');
-
 				const attrEl = $('.external-links > a');
+				var attrName = 'data-v-1a2276d0';
 
 				if (attrEl){
-					// Like normal, add MAL link below streaming links
-					const attrName = attrEl.attributes[0].name;
+					// Like normal, add MAL link below streaming links, get the attribute name of the other links
+					attrName = attrEl.attributes[0].name;
 
-					const malLink = anilist.helpers.createElement('a', {
-						[attrName]: '',
-						class: 'external-link MyAnimeList',
-						target: '_blank',
-						href: `https://myanimelist.net/${isAnime ? 'anime' : 'manga'}/${malID}/`
-					});
-	
-					malLink.innerText = 'MyAnimeList';
-	
-					extLinksEl.append(malLink);
-				}else{			
+				}else{	
+					// No external links, lets create the header
 					if (!$('.sidebar')) return;
 					const sidebarEl = $('.sidebar');
 
@@ -156,7 +156,7 @@
 						// There are no external or streaming links then recreate the div		
 						extLinksEl = anilist.helpers.createElement('div', {
 							['data-v-1a2276d0']: '',
-							class: 'external-links'
+							class: 'external-links external-links-extras'
 						});
 						sidebarEl.append(extLinksEl);
 
@@ -166,17 +166,18 @@
 						extLinksTitle.innerText = "External & Streaming Links";
 						extLinksEl.append(extLinksTitle);
 					}
-
-					const malLink = anilist.helpers.createElement('a', {
-						['data-v-1a2276d0']: '',
-						class: 'external-link MyAnimeList',
-						target: '_blank',
-						href: `https://myanimelist.net/${isAnime ? 'anime' : 'manga'}/${malID}/`
-					});
-					malLink.innerText = 'MyAnimeList';
-					
-					extLinksEl.append(malLink);
 				}
+
+				// Create the link
+				const malLink = anilist.helpers.createElement('a', {
+					[attrName]: '',
+					class: 'external-link MyAnimeList',
+					target: '_blank',
+					href: `https://myanimelist.net/${isAnime ? 'anime' : 'manga'}/${malID}/`
+				});
+				malLink.innerText = 'MyAnimeList';
+				
+				extLinksEl.append(malLink);
 			},
 
 			addMalScore() {
@@ -240,7 +241,6 @@
 					// this will append just in case it didn't get caught before
 					$('.data').append(malScoreContainer);
 				}
-
 			},
 
 			async displayCharacters(malID, isAnime = true) {

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -456,16 +456,9 @@
 							class: `tag ${index > 5 ? 'showmore hide' : ''}`
 						}, { marginBottom: '10px' });
 
-						// Determine prefix and add the song
-						var prefix = "";
-						if (song.includes("No opening themes")){
-							// No prefix
-						}else if (song.match(/(^[0-9])/)){
-							prefix = "#";
-						}else if (!song.startsWith("#")){
-							prefix = "#" + (parseInt(index, 10) + 1).toString() + ": ";
-						}
-						opCard.innerText = `${prefix}${song}`;
+						opCard.innerText = song.includes('No opening themes')
+							? song.replace('Help improve our database by adding an opening theme here.', '') // This probably should not be displayed on anilist
+							: `#${parseInt(index, 10) + 1}: ${song.replace(/^(#)?\d+:/, '')}`;
 						opContainer.append(opCard);
 					}
 
@@ -520,17 +513,10 @@
 							[attrName]: '',
 							class: `tag ${index > 5 ? 'showmore hide' : ''}`
 						}, { marginBottom: '10px' });
-						
-						// Determine prefix and add the song
-						var prefix = "";
-						if (song.includes("No ending themes")){
-							// No prefix
-						}else if (song.match(/(^[0-9])/)){
-							prefix = "#";
-						}else if (!song.startsWith("#")){
-							prefix = "#" + (parseInt(index, 10) + 1).toString() + ": ";
-						}
-						edCard.innerText = `${prefix}${song}`;
+
+						edCard.innerText = song.includes('No ending themes')
+							? song.replace('Help improve our database by adding an ending theme here.', '') // This probably should not be displayed on anilist
+							: `#${parseInt(index, 10) + 1}: ${song.replace(/^(#)?\d+:/, '')}`;
 						edContainer.append(edCard);
 					}
 

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -38,14 +38,14 @@
 			padding: 3px 6px;
 			margin-left: 5px;
 		}
-		.characters .grid-wrap{
+		.characters .grid-wrap, .staff .grid-wrap{
 			margin-top: 10px;
 		}
 		.characters .character-header{
 			font-size: 1.4rem;
 			font-weight: 500;
 		}
-		.characters .switcher-holder{
+		.characters .switcher-holder, .staff .switcher-holder, .staff .link{
 			display: inline;
 		}
 		.characters .toggle {
@@ -119,7 +119,8 @@
 
 				if ($('.overview')) {
 					await this.displayCharacters(this.currentData.mal_id, isAnime);
-					anilist.helpers.addViewToggle('.characters .switcher-holder, .staff .link', '.characters .grid-wrap, .staff .grid-wrap');
+					this.displayStaffViewSwitcher();
+					anilist.helpers.addViewToggle('.characters .switcher-holder, .staff .switcher-holder', '.characters .grid-wrap, .staff .grid-wrap');
 					if (isAnime) await this.displayOpEd(this.currentData.mal_id);
 				}
 
@@ -366,6 +367,18 @@
 						$('.characters .character-header').style.display = 'inline';
 						$('.characters .link').style.display = 'none';
 					}
+				} catch (err) {
+					console.error(err);
+				}
+			},
+
+			displayStaffViewSwitcher(){
+				if ($('.staff .switcher-holder')) return;
+
+				try {
+					$('.staff .link').insertAdjacentHTML('afterend', `
+						<div class="switcher-holder"></div>
+					`);
 				} catch (err) {
 					console.error(err);
 				}

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -850,7 +850,7 @@
 							
 							// Create score p
 							const score = anilist.helpers.createElement('p', { class: 'review-score' });
-							score.innerHTML = data.score.toString();
+							score.innerText = data.score.toString();
 							if (data.score < 50){
 								score.style.background = "rgb(var(--color-red))";
 							}else if (data.score <= 65){

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -214,20 +214,14 @@
 				malScoreContainer.append(malScoreHeader, malScoreValue);
 
 				var added = false;
-				const dataNodes = $('.data').childNodes;
+				const dataNodes = $('.data').children;
 
 				for(var i = 0; i < dataNodes.length; i++){
-					if(dataNodes[i].innerHTML != null && dataNodes[i].innerHTML.includes('Mean Score')){
-						// probably not necessary with the if below, but I want it to be after the mean score for sure
-						var node = dataNodes[i];
-						var origClass = node.className;
-						node.className = "meanscore";
-						$('.meanscore').after(malScoreContainer);
-						node.className = origClass; 
-						added = true;
-						break;
-					}else if (dataNodes[i].innerHTML != null && dataNodes[i].innerHTML.includes('Popularity')){
-						// this will append in the correct place if there is no anilist score
+					if (dataNodes[i].innerHTML != null && dataNodes[i].innerHTML.includes('Popularity')){
+						// Place the MAL score before the anilist popularity, this will ensure it is just after the AL score
+						// In the case where there is no AL score, this will still ensure it is in the expected location
+
+						// So we can do the .before, the popularity element needs a unique class name
 						var node = dataNodes[i];
 						var origClass = node.className;
 						node.className = "popularity";

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -731,7 +731,7 @@
 
 		},
 
-		seasonal:{
+		seasonal: {
 			running: false,
 
 			stopRunning() {
@@ -752,27 +752,31 @@
 				if (!$('.browse-wrap .dropdown .primary-links .secondary-links')) return;
 				if ($('.seasonal-anime')) return;
  
-				const linksEl = $('.secondary-links')
-				const attrName = linksEl.childNodes[0].attributes[0].name;
+				const linksEl = $('.secondary-links');
+				const attrName = $('.secondary-links > a').attributes[0].name;
 
 				// Determine the year and season
 				const year = new Date().getFullYear();
 				const month = new Date().getMonth();
-				var season = "";
-				if (month <= 2){
-					season = "WINTER";
-				}else if(month <= 5){
-					season = "SPRING";
-				}else if(month <= 8){
-					season = "SUMMER";
-				}else{
-					season = "FALL";
+
+				let season = '';
+				if (month <= 2) {
+					season = 'WINTER';
+				} else if (month <= 5) {
+					season = 'SPRING';
+				} else if (month <= 8) {
+					season = 'SUMMER';
+				} else {
+					season = 'FALL';
 				}
-				var ref = "/search/anime?year=" + year + "&season=" + season;
 
 				// Create the new element and add to the dropdown
-				const link = anilist.helpers.createElement('a', { class: 'seasonal-anime', [attrName]: '', href: ref});
-				link.innerHTML = "Seasonal"
+				const link = anilist.helpers.createElement('a', {
+					class: 'seasonal-anime',
+					[attrName]: '',
+					href: `/search/anime?year=${year}&season=${season}`,
+				}, { marginTop: '5px' });
+				link.innerText = "Seasonal"
 
 				linksEl.append(link);
 			}
@@ -1202,6 +1206,7 @@
 				anilist.social.init();
 
 			}
+
 			anilist.seasonal.init();
 		}
 

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -459,8 +459,10 @@
 							[attrName]: '',
 							class: `tag ${index > 5 ? 'showmore hide' : ''}`
 						}, { marginBottom: '10px' });
-						if (!song.startsWith("#")){
-							opCard.innerText = `#${parseInt(index, 10) + 1}: ${song}`;
+						if (song.match(/(^[0-9])/)){
+							opCard.innerText = `#${song}`;
+						}else if (!song.startsWith("#")){
+							opCard.innerText = `#${parseInt(index, 10) + 1}: ${song}`; 
 						}else{
 							opCard.innerText = `${song}`;
 						}
@@ -519,7 +521,9 @@
 							class: `tag ${index > 5 ? 'showmore hide' : ''}`
 						}, { marginBottom: '10px' });
 						// Only add num if not already
-						if (!song.startsWith("#")){
+						if (song.match(/(^[0-9])/)){
+							edCard.innerText = `#${song}`;
+						}else if (!song.startsWith("#")){
 							edCard.innerText = `#${parseInt(index, 10) + 1}: ${song}`;
 						}else{
 							edCard.innerText = `${song}`;

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -455,13 +455,17 @@
 							[attrName]: '',
 							class: `tag ${index > 5 ? 'showmore hide' : ''}`
 						}, { marginBottom: '10px' });
-						if (song.match(/(^[0-9])/)){
-							opCard.innerText = `#${song}`;
+
+						// Determine prefix and add the song
+						var prefix = "";
+						if (song.includes("No opening themes")){
+							// No prefix
+						}else if (song.match(/(^[0-9])/)){
+							prefix = "#";
 						}else if (!song.startsWith("#")){
-							opCard.innerText = `#${parseInt(index, 10) + 1}: ${song}`; 
-						}else{
-							opCard.innerText = `${song}`;
+							prefix = "#" + (parseInt(index, 10) + 1).toString() + ": ";
 						}
+						opCard.innerText = `${prefix}${song}`;
 						opContainer.append(opCard);
 					}
 
@@ -516,14 +520,17 @@
 							[attrName]: '',
 							class: `tag ${index > 5 ? 'showmore hide' : ''}`
 						}, { marginBottom: '10px' });
-						// Only add num if not already
-						if (song.match(/(^[0-9])/)){
-							edCard.innerText = `#${song}`;
+						
+						// Determine prefix and add the song
+						var prefix = "";
+						if (song.includes("No ending themes")){
+							// No prefix
+						}else if (song.match(/(^[0-9])/)){
+							prefix = "#";
 						}else if (!song.startsWith("#")){
-							edCard.innerText = `#${parseInt(index, 10) + 1}: ${song}`;
-						}else{
-							edCard.innerText = `${song}`;
+							prefix = "#" + (parseInt(index, 10) + 1).toString() + ": ";
 						}
+						edCard.innerText = `${prefix}${song}`;
 						edContainer.append(edCard);
 					}
 

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -755,26 +755,11 @@
 				const linksEl = $('.secondary-links');
 				const attrName = $('.secondary-links > a').attributes[0].name;
 
-				// Determine the year and season
-				const year = new Date().getFullYear();
-				const month = new Date().getMonth();
-
-				let season = '';
-				if (month <= 2) {
-					season = 'WINTER';
-				} else if (month <= 5) {
-					season = 'SPRING';
-				} else if (month <= 8) {
-					season = 'SUMMER';
-				} else {
-					season = 'FALL';
-				}
-
 				// Create the new element and add to the dropdown
 				const link = anilist.helpers.createElement('a', {
 					class: 'seasonal-anime',
 					[attrName]: '',
-					href: `/search/anime?year=${year}&season=${season}`,
+					href: '/search/anime/this-season',
 				}, { marginTop: '5px' });
 				link.innerText = "Seasonal"
 

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -161,8 +161,6 @@
 				const attrEl = $('.external-links .external-links-wrap > a');
 				let attrName;
 
-				console.log(attrEl);
-
 				if (attrEl) {
 					attrName = attrEl.attributes[0].name;
 				} else {

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -38,12 +38,17 @@
 			padding: 3px 6px;
 			margin-left: 5px;
 		}
-		.characters .link,
-		.staff .link {
-			pointer-events: none;
-			cursor: initial !important;
+		.characters .grid-wrap{
+			margin-top: 10px;
 		}
-		.characters .link .toggle {
+		.characters .character-header{
+			font-size: 1.4rem;
+			font-weight: 500;
+		}
+		.characters .switcher-holder{
+			display: inline;
+		}
+		.characters .toggle {
 			cursor: pointer;
 		}
 		.characters .link *,
@@ -114,7 +119,7 @@
 
 				if ($('.overview')) {
 					await this.displayCharacters(this.currentData.mal_id, isAnime);
-					anilist.helpers.addViewToggle('.characters .link, .staff .link', '.characters .grid-wrap, .staff .grid-wrap');
+					anilist.helpers.addViewToggle('.characters .switcher-holder, .staff .link', '.characters .grid-wrap, .staff .grid-wrap');
 					if (isAnime) await this.displayOpEd(this.currentData.mal_id);
 				}
 
@@ -178,7 +183,7 @@
 				malScoreContainer.append(malScoreHeader, malScoreValue);
 
 				const dataNodes = $('.data').childNodes;
-				
+
 				for(var i = 0; i < dataNodes.length; i++){
 					if(dataNodes[i].innerHTML != null && dataNodes[i].innerHTML.includes('Mean Score')){
 						var node = dataNodes[i];
@@ -327,35 +332,39 @@
 						$('.characters').append(toggleCharacters);
 					}
 
-					$('.characters .link').remove(); // This is to remove the click listener
-					$('.characters .grid-wrap').insertAdjacentHTML('beforebegin', `
-						<h2 class="link">
-							<span class="character-header">Characters</span>
-							<span class="toggle"></span>
-						</h2>
-					`);
 
-					$('.characters .link .toggle').addEventListener('click', () => {
+					$('.characters .link').innerHTML = "AniList Characters";
+					$('.characters .link').insertAdjacentHTML('afterend', `
+						<span class="character-header">MAL Characters</span>
+						<span class="toggle"></span>
+						<div class="switcher-holder"></div>
+					`);
+					
+					$('.characters .toggle').addEventListener('click', () => {
 						if ($('.characters').classList.contains('mal')) {
 							$('.characters').classList.remove('mal');
 							$('.characters .toggle').innerText = 'Switch to MyAnimeList';
-							$('.characters .character-header').innerText = 'AniList Characters';
+							$('.characters .character-header').style.display = 'none';
+							$('.characters .link').style.display = 'inline';
 							anilist.storage.set('activeCharacters', 'anilist');
 						} else {
 							$('.characters').classList.add('mal');
 							$('.characters .toggle').innerText = 'Switch to AniList';
-							$('.characters .character-header').innerText = 'MAL Characters';
+							$('.characters .character-header').style.display = 'inline';
+							$('.characters .link').style.display = 'none';
 							anilist.storage.set('activeCharacters', 'mal');
 						}
 					});
 
 					if (anilist.storage.get('activeCharacters') === 'anilist') {
 						$('.characters .toggle').innerText = 'Switch to MyAnimeList';
-						$('.characters .character-header').innerText = 'AniList Characters';
+						$('.characters .character-header').style.display = 'none';
+						$('.characters .link').style.display = 'inline';
 					} else {
 						$('.characters').classList.add('mal');
 						$('.characters .toggle').innerText = 'Switch to AniList';
-						$('.characters .character-header').innerText = 'MAL Characters';
+						$('.characters .character-header').style.display = 'inline';
+						$('.characters .link').style.display = 'none';
 					}
 				} catch (err) {
 					console.error(err);
@@ -790,7 +799,6 @@
 					});
 
 					container.append(viewSwitcher);
-
 				}
 
 				switch (anilist.storage.get('view')) {

--- a/anilist-extras.user.js
+++ b/anilist-extras.user.js
@@ -130,7 +130,7 @@
 			addMalLink(malID, isAnime) {
 				if ($('.MyAnimeList')) return;
 
-				const extLinksEl = $('.external-links');
+				var extLinksEl = $('.external-links');
 
 				const attrEl = $('.external-links > a');
 
@@ -148,23 +148,25 @@
 					malLink.innerText = 'MyAnimeList';
 	
 					extLinksEl.append(malLink);
-				}else{
+				}else{			
 					if (!$('.sidebar')) return;
-					// There are no external or streaming links then recreate the div					
 					const sidebarEl = $('.sidebar');
-					const extLinksEl = anilist.helpers.createElement('div', {
-						['data-v-1a2276d0']: '',
-						class: 'external-links'
-					});
 
-					// Create the title
-					const extLinksTitle = anilist.helpers.createElement('h2', {
-					});
-					extLinksTitle.innerText = "External & Streaming Links";
-					extLinksEl.append(extLinksTitle);
+					if (extLinksEl == null){
+						// There are no external or streaming links then recreate the div		
+						extLinksEl = anilist.helpers.createElement('div', {
+							['data-v-1a2276d0']: '',
+							class: 'external-links'
+						});
+						sidebarEl.append(extLinksEl);
 
-					sidebarEl.append(extLinksEl);
-					
+						// Create the title
+						const extLinksTitle = anilist.helpers.createElement('h2', {
+						});
+						extLinksTitle.innerText = "External & Streaming Links";
+						extLinksEl.append(extLinksTitle);
+					}
+
 					const malLink = anilist.helpers.createElement('a', {
 						['data-v-1a2276d0']: '',
 						class: 'external-link MyAnimeList',
@@ -172,7 +174,7 @@
 						href: `https://myanimelist.net/${isAnime ? 'anime' : 'manga'}/${malID}/`
 					});
 					malLink.innerText = 'MyAnimeList';
-	
+					
 					extLinksEl.append(malLink);
 				}
 			},

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
 	"manifest_version": 2,
-	"name": "AniList Extras",
+	"name": "AniList Extras (Updated)",
 	"description": "Adds a few additional features to AniList.",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"minimum_chrome_version": "60.0.3112",
 
 	"icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 2,
 	"name": "AniList Extras (Updated)",
 	"description": "Adds a few additional features to AniList.",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"minimum_chrome_version": "60.0.3112",
 
 	"icons": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
 	"name": "anilist-extras",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Adds a few additional features to AniList.",
 	"scripts": {
 		"test": "eslint ."
 	},
-	"repository": "https://github.com/pilar6195/AniList-Extras.git",
-	"author": "pilar6195 (https://github.com/pilar6195)",
+	"repository": "https://github.com/duncanlang/AniList-Extras.git",
+	"author": "Duncan Lang (https://github.com/duncanlang) (Original https://github.com/pilar6195))",
 	"license": "MIT",
 	"engines": {
 		"node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "anilist-extras",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "Adds a few additional features to AniList.",
 	"scripts": {
 		"test": "eslint ."


### PR DESCRIPTION
-Moved MAL score to be below the mean score instead of the bottom of the sidebar
-Changed how the characters header works so the AniList characters header can link to the characters page like it normally would
-Also changed the staff header to link the the staff page again
-Fixed the double numbering on OPs and EDs. The MAL entries seemed to already come with numbers so I made it only add the number if it does not start with a #