### PR TITLE
Replace Jikan with Tenrai

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,7 @@
 
 	"host_permissions": [
 		"https://graphql.anilist.co/*",
-		"https://api.jikan.moe/*"
+		"https://api.tenrai.org/*"
 	],
 
 	"content_scripts": [

--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -355,7 +355,7 @@ export const anilistApi = async (
 const malApiRateLimit = new RateLimit(3, 2000);
 
 /**
- * Send a request to the Jikan API. Returns cached data if available.
+ * Send a request to the Tenrai API. Returns cached data if available.
  */
 export const malApi = async (path: string, cacheTime: number | false = ONE_HOUR): Promise<any> => {
 	if (cacheTime !== false) {
@@ -369,7 +369,7 @@ export const malApi = async (path: string, cacheTime: number | false = ONE_HOUR)
 	const maxRetries = 3;
 
 	const performRequest = async (attempt: number = 0): Promise<any> => {
-		const response = await request(`https://api.jikan.moe/v4/${path}`);
+		const response = await request(`https://api.tenrai.org/v1/${path}`);
 
 		if (response.status === 429) {
 			if (attempt < maxRetries) {


### PR DESCRIPTION
The Jikan API is being discontinued on October 1 (with brownouts starting on Sept 1, but it's already been down quite regularly in the past few months), as was announced on the Jikan Discord server a couple of months ago:
<details>
<summary>Screenshot of the announcement from the discord server:</summary>
<img width="833" height="1116" alt="image" src="https://github.com/user-attachments/assets/d638f640-0392-4fcd-83c7-5287a16432bd" />
</details>

Since then, another user has created [Tenrai](https://tenrai.org/) which has a drop-in replacement API. As far as I'm aware, this is the only alternative at the moment, aside from self-hosting Jikan. From my personal experience, Tenrai has so far had consistent uptime since it launched last month.

My changes in the pull request are just a simple change of api.jikan.moe -> api.tenrai.org.


**Side question** (which is unrelated to this pull request): what is the reason for the Firefox store not being updated? I personally use Firefox so I'd love to see if it could be updated again.