### PR TITLE
Add review ratings to main anime/manga overview page

### DIFF
--- a/src/modules/anilist/addReviewRatings.ts
+++ b/src/modules/anilist/addReviewRatings.ts
@@ -128,7 +128,8 @@ registerModule.anilist({
 
 	validate({ currentPage }) {
 		return (currentPage.pathname.startsWith('/home') && isUI.desktop) || // Starts with /home. More than likely the user is on the homepage.
-				currentPage.pathname.endsWith('/reviews'); // Ends with /reviews. Either on the overall reviews or anime reviews page.
+				currentPage.pathname.endsWith('/reviews') || // Ends with /reviews. Either on the overall reviews or anime reviews page.
+				/^\/(anime|manga)\/\d+\/.+\/?$/.test(currentPage.pathname); // Reviews also appear on the base anime/manga pages
 	},
 
 	async load() {


### PR DESCRIPTION
A small change to run the addReviewRatings module on the main anime/manga (overview) page, as reviews also appear there.

Current:
<img width="584" height="225" alt="image" src="https://github.com/user-attachments/assets/2111b47f-0f13-4e6a-9258-5039a2a185b8" />

Change:
<img width="573" height="236" alt="image" src="https://github.com/user-attachments/assets/dcf20dfd-aece-468f-b9f2-02ebbe4ef149" />

And another screenshot, for full context of where the change is:
<img width="1620" height="605" alt="image" src="https://github.com/user-attachments/assets/f4756d9c-ac07-42d5-8334-57a9279a1d95" />
